### PR TITLE
Add on_fail / on_fail_interactive to control failure behaviour

### DIFF
--- a/R/non_interactive_summary.R
+++ b/R/non_interactive_summary.R
@@ -24,8 +24,9 @@ assign_outcome <- function(outcome) {
 # having this as a named function means that CMD check will not complain about the use of cat and packageStartupMessage in .onLoad
 non_interactive_exit <- function( e ) {
     if( exists('outcomes', where = e) && nrow(get('outcomes', pos = e)) ) {
-         tests.total <- nrow(get('outcomes', pos = e))
-         tests.failed <- sum(! get('outcomes', pos = e)$status) 
+         outcomes <- get('outcomes', pos = e)
+         tests.total <- nrow(outcomes)
+         tests.failed <- sum(! outcomes$status)
          if ( exists('errors', where = e) ) {
              tests.errors <- get('errors', pos = e)
              write_ut_lines(
@@ -35,6 +36,7 @@ non_interactive_exit <- function( e ) {
          } else if (tests.failed) {
              write_ut_lines(
                  paste("# Looks like you failed", tests.failed, "of", tests.total, "tests.", collapse = " "),
+                 if (on_fail() == "summary") paste0("# ", which(!outcomes$status), ": ", outcomes[!outcomes$status, "description"]) else NULL,
                  NULL)
              # We need to alter the status code, stop() doesn't work, not allowed to use .Last, should only happen as script is terminating anyway.
              quit(save = "no", status = 10, runLast=FALSE)

--- a/R/ok.R
+++ b/R/ok.R
@@ -85,6 +85,13 @@ ok <- function(
         if (any(nzchar(outcome[1, "output"]))) outcome[1, "output"],
         NULL
     )
+    if (isFALSE(outcome[1,'status'])) {
+        switch(on_fail(),
+            stop = stop('Test failure, not continuing'),
+            warn = warning("Failed unittest: ", description, call. = FALSE),
+            NULL
+        )
+    }
     invisible(result)
 }
 

--- a/R/ok.R
+++ b/R/ok.R
@@ -88,7 +88,11 @@ ok <- function(
     if (isFALSE(outcome[1,'status'])) {
         switch(on_fail(),
             stop = stop('Test failure, not continuing'),
-            warn = warning("Failed unittest: ", description, call. = FALSE),
+            # TODO: Number of failing test, as per non-interactive summary
+            # TODO: How to warn that we can't print a summary, because warnings are errors? message() would be lost in noise
+            summary = if (interactive() && getOption("warn") == 0) {
+                warning("Failed unittest: ", description, call. = FALSE)
+            },
             NULL
         )
     }

--- a/R/options.R
+++ b/R/options.R
@@ -43,3 +43,14 @@ output_ansi_color <- function () {
     }
     return(FALSE)
 }
+
+on_fail <- function () {
+    if (interactive()) {
+        out <- getOption("unittest.on_fail_interactive", Sys.getenv("UT_ON_FAIL_INTERACTIVE", unset = "warn"))
+    } else {
+        out <- getOption("unittest.on_fail", Sys.getenv("UT_ON_FAIL", unset = "summary"))
+    }
+    if (!nzchar(out)) return("continue")
+    if (out %in% c('summary', 'stop', 'warn')) return(out)
+    stop("Unknown unittest on_fail setting, should be one of '', 'summary', 'stop', 'warn': ", out)
+}

--- a/R/options.R
+++ b/R/options.R
@@ -45,12 +45,7 @@ output_ansi_color <- function () {
 }
 
 on_fail <- function () {
-    if (interactive()) {
-        out <- getOption("unittest.on_fail_interactive", Sys.getenv("UT_ON_FAIL_INTERACTIVE", unset = "warn"))
-    } else {
-        out <- getOption("unittest.on_fail", Sys.getenv("UT_ON_FAIL", unset = "summary"))
-    }
-    if (!nzchar(out)) return("continue")
-    if (out %in% c('summary', 'stop', 'warn')) return(out)
-    stop("Unknown unittest on_fail setting, should be one of '', 'summary', 'stop', 'warn': ", out)
+    out <- getOption("unittest.on_fail", Sys.getenv("UT_ON_FAIL", unset = "summary"))
+    if (out %in% c('quiet', 'summary', 'stop')) return(out)
+    stop("Unknown unittest on_fail setting, should be one of 'quiet', 'summary', 'stop': ", out)
 }


### PR DESCRIPTION
This is an attempt to solve a few things:

* When doing ``source("test-foo.R")``, you get no summary at the end. Warning on test failures produces something similar to a summary.
* CRAN test failures will print the last few lines of test output, which are useless if the failure was in the middle. Listing the description of failing tests makes the output more useful.
* It's nice to be able to stop on failures sometimes, so you can inspect state after the test failure.

But:

* Turning on warn/summary for interactive/non-interactive may not work with everyone's workflow, particularly the former if you work with ``options(warn = 2)``
* The options feel somewhat overloaded, summary and warn are very different things
* I don't like having both ``option()`` & environment variable versions of the same thing, but the former is useful if you want to always stop on "not ok", the latter if you want to do it once for a test script.