### PR TITLE
ut_cmp: Expose context_lines as parameter & option

### DIFF
--- a/man/ut_cmp.Rd
+++ b/man/ut_cmp.Rd
@@ -10,8 +10,18 @@
 }
 
 \usage{
-  ut_cmp_equal(a, b, filter = NULL, deparse_frame = -1, ...)
-  ut_cmp_identical(a, b, filter = NULL, deparse_frame = -1)
+ut_cmp_equal(
+        a, b,
+        filter = NULL,
+        deparse_frame = -1,
+        context_lines = getOption("unittest.cmp_context", 1e8),
+        ... )
+
+ut_cmp_identical(
+        a, b,
+        filter = NULL,
+        deparse_frame = -1,
+        context_lines = getOption("unittest.cmp_context", 1e8) )
 }
 
 \arguments{
@@ -21,6 +31,9 @@
   \item{deparse_frame}{
     Tell \code{\link{sys.call}} which frame to deparse to get original expressions.
     Set to \code{-2} when making a helper function, see examples.
+  }
+  \item{context_lines}{
+    Number of lines of context surrounding changed lines to print.
   }
   \item{...}{Other arguments passed directly to \code{\link{all.equal}}}
 }

--- a/tests/test_ut_cmp.R
+++ b/tests/test_ut_cmp.R
@@ -193,6 +193,33 @@ ok_group("output_diff", (function () {
     ok(!all(grepl('\033\\[.*?m', ut_cmp_identical(1L, 2L), perl = TRUE)), "cli.num_colors honoured (no escape code in output)")
 })())
 
+ok_group("context_lines", local({
+    ok(cmp_lines(ut_cmp_identical(as.list(1:10), {x <- 1:10 ; x[[5]] <- 99 ; as.list(x)}, context_lines = 3),
+        '--- as.list(1:10)',
+        '+++ {',
+        '[1] 4',
+        '',
+        '[[5]]',
+        '[1] [-5-]{+99+}',
+        '',
+        '[[6]]',
+        '[1] 6',
+        NULL), "ut_cmp_identical: context_lines = 3 returned 3 lines of context")
+
+    ok(cmp_lines(ut_cmp_equal(as.list(1:10), {x <- 1:10 ; x[[5]] <- 99 ; as.list(x)}, context_lines = 3),
+        'Component 5: Mean relative difference: 18.8',
+        '--- as.list(1:10)',
+        '+++ {',
+        '[1] 4',
+        '',
+        '[[5]]',
+        '[1] [-5-]{+99+}',
+        '',
+        '[[6]]',
+        '[1] 6',
+        NULL), "ut_cmp_equal: context_lines = 3 returned 3 lines of context")
+}))
+
 ok_group("ut_cmp_identical:nogit", mock(unittest:::git_binary, function () "/not-here", {
     ok(isTRUE(ut_cmp_identical(4, 4)), "Identical objects return true")
     ok(cmp_lines(ut_cmp_identical(as.integer(4), 4),


### PR DESCRIPTION
Allow context line count to be altered both within a call to ut_cmp_* or globally by setting an option.